### PR TITLE
Feature: generate graphia-input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,9 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "clap 4.4.7",
+ "prio-graph",
+ "serde",
+ "serde_json",
  "solana-alt-store",
  "solana-core",
  "solana-sdk",
@@ -3345,6 +3348,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "prio-graph"
+version = "0.1.0"
+source = "git+https://github.com/apfitzge/prio-graph.git?rev=fcf06ed020d6dd5325122789cd3633547c6d023c#fcf06ed020d6dd5325122789cd3633547c6d023c"
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4056,9 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [dependencies]
 bincode = { version = "1.3.3" }
 clap = { version = "4.3.11", features = ["derive"] }
+prio-graph = { git = "https://github.com/apfitzge/prio-graph.git", rev = "fcf06ed020d6dd5325122789cd3633547c6d023c" }
+serde = { version = "1.0.190" }
+serde_json = { version = "1.0.108" }
 solana-core = { version = "1.17.3" }
 solana-sdk = { version = "1.17.3" }
 solana-alt-store = { git = "https://github.com/apfitzge/solana-alt-store.git" }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Usage: banking-trace-tool --path <PATH> <COMMAND>
 
 Commands:
   account-usage     Get account usage statistics for a given slot range
+  graphia-input     Write graphia json input file for a given slot
   slot-ranges       Get the ranges of slots for data in directory
   update-alt-store  Update Address-Lookup-Table store for tables used in a given slot-range
   help              Print this message or the help of the given subcommand(s)

--- a/src/account_usage.rs
+++ b/src/account_usage.rs
@@ -109,8 +109,12 @@ impl AccountUsageHandler {
     }
 
     fn handle_block_and_bank_hash(&mut self, slot: Slot) {
-        if !self.range.contains(&slot) && slot > *self.range.end() {
-            self.done = true;
+        if !self.range.contains(&slot) {
+            if slot > *self.range.end() {
+                self.done = true;
+            }
+        } else {
+            self.current_packet_batches.clear();
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,6 +18,14 @@ pub struct Cli {
 pub enum TraceToolMode {
     /// Get account usage statistics for a given slot range.
     AccountUsage(SlotRange),
+    /// Write graphia json input file for a given slot.
+    GraphiaInput {
+        /// The slot to write the graphia input file for.
+        slot: Slot,
+        /// The filepath to write the graphia input file to.
+        #[clap(default_value = "graphia_input.json")]
+        output: PathBuf,
+    },
     /// Get the ranges of slots for data in directory.
     SlotRanges,
     /// Update Address-Lookup-Table store for tables used in a given slot-range.

--- a/src/graphia_input.rs
+++ b/src/graphia_input.rs
@@ -74,12 +74,9 @@ impl GraphiaInputHandler {
             })
             .filter_map(|(tx, priority, requested_cus)| {
                 let hash = tx.get_message().message.hash();
-                let tx = SanitizedTransaction::try_new(tx, hash, false, &self.alt_store)
-                    // .ok()
+                SanitizedTransaction::try_new(tx, hash, false, &self.alt_store)
+                    .ok()
                     .map(|tx| (tx, priority, requested_cus))
-                    .unwrap();
-
-                Some(tx)
             })
             .collect();
 

--- a/src/graphia_input.rs
+++ b/src/graphia_input.rs
@@ -1,0 +1,284 @@
+use {
+    crate::process::process_event_files,
+    prio_graph::{AccessKind, PrioGraph, TopLevelId},
+    serde::Serialize,
+    solana_alt_store::Store,
+    solana_core::banking_trace::{BankingPacketBatch, ChannelLabel, TimedTracedEvent, TracedEvent},
+    solana_sdk::{
+        borsh0_10::try_from_slice_unchecked,
+        clock::Slot,
+        compute_budget::{self, ComputeBudgetInstruction},
+        transaction::{SanitizedTransaction, SanitizedVersionedTransaction, VersionedTransaction},
+    },
+    std::path::PathBuf,
+};
+
+pub fn graphia_input(
+    event_file_paths: &[PathBuf],
+    slot: Slot,
+    output: PathBuf,
+) -> std::io::Result<()> {
+    let mut handler = GraphiaInputHandler::new(slot);
+    process_event_files(event_file_paths, &mut |event| handler.handle_event(event))?;
+    handler.report(output)
+}
+
+struct GraphiaInputHandler {
+    slot: Slot,
+    current_packet_batches: Vec<BankingPacketBatch>,
+    done: bool,
+    alt_store: Store,
+}
+
+impl GraphiaInputHandler {
+    pub fn new(slot: Slot) -> Self {
+        const ALT_STORE_PATH: &str = "alt-store.bin";
+
+        Self {
+            slot,
+            current_packet_batches: Vec::new(),
+            done: false,
+            alt_store: Store::load_or_create(ALT_STORE_PATH).expect("failed to load alt store"),
+        }
+    }
+
+    pub fn handle_event(&mut self, TimedTracedEvent(_timestamp, event): TimedTracedEvent) {
+        if self.done {
+            return;
+        }
+
+        match event {
+            TracedEvent::PacketBatch(label, packet_batches) => {
+                self.handle_packet_batches(label, packet_batches)
+            }
+            TracedEvent::BlockAndBankHash(slot, _, _) => self.handle_block_and_bank_hash(slot),
+        }
+    }
+
+    /// Write JSON for prio-graph of the current slot.
+    /// Each transaction has following attributes:
+    /// - Signature
+    /// - Priority
+    /// - Requested CUs
+    pub fn report(&self, output: PathBuf) -> std::io::Result<()> {
+        // Buffer all (transaction, priority, requested_cus) tuples.
+        let mut transaction_tuples: Vec<_> = self
+            .current_packet_batches
+            .iter()
+            .flat_map(|b| b.0.iter().flat_map(|b| b.iter().cloned()))
+            .filter_map(|p| bincode::deserialize::<VersionedTransaction>(p.data(..)?).ok())
+            .filter_map(|tx| SanitizedVersionedTransaction::try_from(tx).ok())
+            .map(|tx| {
+                let (priority, requested_cus) = get_priority_and_requested_cus(&tx);
+                (tx, priority, requested_cus)
+            })
+            .filter_map(|(tx, priority, requested_cus)| {
+                let hash = tx.get_message().message.hash();
+                let tx = SanitizedTransaction::try_new(tx, hash, false, &self.alt_store)
+                    // .ok()
+                    .map(|tx| (tx, priority, requested_cus))
+                    .unwrap();
+
+                Some(tx)
+            })
+            .collect();
+
+        // Sort by priority. Highest priority first.
+        transaction_tuples.sort_by(|a, b| b.1.cmp(&a.1));
+
+        // Insert into prio-graph in order of priority.
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+        struct PriorityIndex {
+            priority: u64,
+            index: usize,
+        }
+        impl TopLevelId<PriorityIndex> for PriorityIndex {
+            fn id(&self) -> PriorityIndex {
+                *self
+            }
+        }
+        impl Ord for PriorityIndex {
+            fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+                self.priority.cmp(&other.priority)
+            }
+        }
+        impl PartialOrd for PriorityIndex {
+            fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        let mut graphia_input = GraphiaInput::default();
+        let mut prio_graph = PrioGraph::new(|pi, _| *pi);
+        let mut transaction_iterator = transaction_tuples.iter().enumerate();
+        let mut insert_next_transaction = |prio_graph: &mut PrioGraph<_, _, _, _>| {
+            let Some((index, (transaction, priority, _))) = transaction_iterator.next() else {
+                return false;
+            };
+
+            let account_locks = transaction.get_account_locks_unchecked();
+            let write_locks = account_locks
+                .writable
+                .iter()
+                .map(|a| (*a, AccessKind::Write));
+            let read_locks = account_locks
+                .readonly
+                .iter()
+                .map(|a| (*a, AccessKind::Read));
+            let transaction_access = write_locks.chain(read_locks);
+
+            prio_graph.insert_transaction(
+                PriorityIndex {
+                    priority: *priority,
+                    index,
+                },
+                transaction_access,
+            );
+
+            true
+        };
+
+        while insert_next_transaction(&mut prio_graph) {}
+
+        let mut edge_count = 0;
+        while !prio_graph.is_empty() {
+            let mut popped = Vec::new();
+            while let Some(id) = prio_graph.pop() {
+                popped.push(id);
+
+                // Insert a new node into the graphia input graph.
+                let (tx, priority, requested_cus) = &transaction_tuples[id.index];
+                graphia_input.graph.nodes.push(GraphiaInputNode {
+                    id: id.index.to_string(),
+                    metadata: GraphiaInputNodeMetaData {
+                        signature: tx.signature().to_string(),
+                        priority: *priority,
+                        requested_cus: *requested_cus,
+                    },
+                });
+            }
+
+            for popped in popped {
+                let unblocked = prio_graph.unblock(&popped);
+
+                // Add edges to graphia input graph.
+                for target in unblocked {
+                    graphia_input.graph.edges.push(GraphiaInputEdge {
+                        id: edge_count.to_string(),
+                        // metadata: GraphiaInputEdgeMetaData {},
+                        source: popped.index.to_string(),
+                        target: target.index.to_string(),
+                    });
+                    edge_count += 1;
+                }
+            }
+        }
+
+        let file = std::fs::File::options()
+            .write(true)
+            .create(true)
+            .append(false)
+            .truncate(true)
+            .open(output)?;
+        serde_json::to_writer(file, &graphia_input).unwrap();
+        Ok(())
+    }
+
+    fn handle_packet_batches(&mut self, label: ChannelLabel, packet_batches: BankingPacketBatch) {
+        if matches!(label, ChannelLabel::NonVote) {
+            self.current_packet_batches.push(packet_batches);
+        }
+    }
+
+    fn handle_block_and_bank_hash(&mut self, slot: Slot) {
+        if self.slot != slot {
+            self.current_packet_batches.clear();
+        } else {
+            self.done = true;
+        }
+    }
+}
+
+#[derive(Default, Serialize)]
+struct GraphiaInput {
+    graph: GraphiaInputGraph,
+}
+
+#[derive(Serialize)]
+struct GraphiaInputGraph {
+    directed: bool,
+    edges: Vec<GraphiaInputEdge>,
+    nodes: Vec<GraphiaInputNode>,
+}
+
+impl Default for GraphiaInputGraph {
+    fn default() -> Self {
+        Self {
+            directed: true,
+            edges: Vec::new(),
+            nodes: Vec::new(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct GraphiaInputEdge {
+    id: String,
+    // metadata: GraphiaInputEdgeMetaData,
+    source: String,
+    target: String,
+}
+
+// #[derive(Serialize)]
+// struct GraphiaInputEdgeMetaData {}
+
+#[derive(Serialize)]
+struct GraphiaInputNode {
+    id: String,
+    metadata: GraphiaInputNodeMetaData,
+}
+
+#[derive(Serialize)]
+struct GraphiaInputNodeMetaData {
+    signature: String,
+    priority: u64,
+    requested_cus: u64,
+}
+
+/// Returns priorty and requested_cus
+fn get_priority_and_requested_cus(tx: &SanitizedVersionedTransaction) -> (u64, u64) {
+    let instructions = tx.get_message().program_instructions_iter();
+    let mut non_compute_budget_ix_count = 0u64;
+    let mut priority = 0u64;
+    let mut requested_cus = None;
+    for (program, ix) in instructions {
+        if !compute_budget::check_id(program) {
+            non_compute_budget_ix_count += 1;
+            continue;
+        }
+
+        let ix: ComputeBudgetInstruction = try_from_slice_unchecked(&ix.data).unwrap();
+        match ix {
+            ComputeBudgetInstruction::RequestUnitsDeprecated {
+                units,
+                additional_fee,
+            } => {
+                requested_cus = Some(units as u64);
+                priority = additional_fee as u64 * 1_000_000 / units as u64;
+            }
+            ComputeBudgetInstruction::RequestHeapFrame(_) => {}
+            ComputeBudgetInstruction::SetComputeUnitLimit(units) => {
+                requested_cus = Some(units as u64)
+            }
+            ComputeBudgetInstruction::SetComputeUnitPrice(cu_price) => priority = cu_price,
+            ComputeBudgetInstruction::SetLoadedAccountsDataSizeLimit(_) => {}
+        }
+    }
+
+    (
+        priority,
+        requested_cus
+            .unwrap_or(non_compute_budget_ix_count * 200_000)
+            .max(1_400_000),
+    )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
-        account_usage::account_usage, cli::Cli, slot_ranges::slot_ranges,
-        update_alt_store::update_alt_store,
+        account_usage::account_usage, cli::Cli, graphia_input::graphia_input,
+        slot_ranges::slot_ranges, update_alt_store::update_alt_store,
     },
     clap::Parser,
     cli::TraceToolMode,
@@ -11,6 +11,7 @@ use {
 
 mod account_usage;
 mod cli;
+mod graphia_input;
 mod process;
 mod setup;
 mod slot_ranges;
@@ -27,6 +28,9 @@ fn main() {
     let event_file_paths = get_event_file_paths(path);
     let result = match mode {
         TraceToolMode::AccountUsage(slot_range) => account_usage(&event_file_paths, slot_range),
+        TraceToolMode::GraphiaInput { slot, output } => {
+            graphia_input(&event_file_paths, slot, output)
+        }
         TraceToolMode::SlotRanges => slot_ranges(&event_file_paths),
         TraceToolMode::UpdateAltStore(slot_range) => {
             update_alt_store(&event_file_paths, slot_range)


### PR DESCRIPTION
- Generate prio-graph visualization input for graphia (https://graphia.app/)
- This input viewed by graphia gives us an interactive view of priority ordered transactions within a slot

Example visualization:
<img width="1672" alt="image" src="https://github.com/apfitzge/banking-trace-tool/assets/13732359/7ea5fd21-6a60-4391-a23b-56f438e0c3b3">

In this example, we have around 6900 non-vote transactions. 74 clusters of transactions are entirely distinct (this was actually lower that I thought it might be).

Within the largest cluster, there's certainly sub-clusterings with only a few edges that could be cut in order to give us a reasonable schedule (out of scope of this change, this change is simply to enable the visualization!)